### PR TITLE
Fix premature release

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -338,13 +338,11 @@ weight: {weight}
             };
         }
 
-        if !changelogs.contains_key(unreleased_version) {
-            fs::write(
-                format!("hugo/rust-changelogs/content/docs/{unreleased_version}.md"),
-                changelog,
-            )
-            .unwrap();
-        }
+        fs::write(
+            format!("hugo/rust-changelogs/content/docs/{unreleased_version}.md"),
+            changelog,
+        )
+        .unwrap();
     }
 
     let mut index = format!(


### PR DESCRIPTION
There was a reoccurring bug where Rust-Changelongs would declare a version released a few days before release day.

This fixes https://github.com/glebpom/rust-changelogs/issues/21