### PR TITLE
ignore relnotes prs that are labeled relnotes-tracking-issue

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -313,6 +313,9 @@ weight: {weight}
         loop {
             for (issue, days_ago) in (&issues_page)
                 .into_iter()
+                .filter(|issue| {
+                    !issue.labels.iter().any(|label| label.name == "relnotes-tracking-issue")
+                })
                 .filter_map(|issue| {
                     issue.closed_at.map(|closed_at| {
                         (


### PR DESCRIPTION
relnotes-tracking-issue prs are usually closed very close to the release and if not then something else has gone wrong, so having them show up on releases.rs is usually wrong.

here's an example:
![image](https://github.com/user-attachments/assets/03e22539-503d-477a-b5ff-e5eb0da0d1d6)

there are 5 relnotes tracking prs that are listed:
- https://github.com/rust-lang/rust/issues/136128. this issue was closed because the change was reverted
- https://github.com/rust-lang/rust/issues/136621. this issue was closed as "duplicate"
- https://github.com/rust-lang/rust/issues/136768. this issue was closed because the change was reverted
- https://github.com/rust-lang/rust/issues/137379. this issue was closed as "duplicate"
- https://github.com/rust-lang/rust/issues/137572. this issue was closed as "duplicate". additionally the original pr (https://github.com/rust-lang/rust/pull/137569) is also shown.
- https://github.com/rust-lang/rust/issues/138183. this issue was closed as no relnotes were needed

i think this does show a slight issue: it would be nice if the two "duplicate" issues that don't show up, even if it would probably be nice if they would. as far as i can tell, according to https://forge.rust-lang.org/release/release-notes.html#automationcommunity-step-1-pr-or-issue-is-labeled-for-release-note-consideration, the release notes are generated for `relnotes` (releases.rs already looks for these), `relnotes-perf` and `finished-final-comment-period` (releaess.rs does not look for these currently).

looking at https://github.com/rust-lang/rust/issues?q=label%3Afinished-final-comment-period+is%3Aclosed, most of those do seem like they should probably be mentioned on releases.rs

if you want, i can also create an entry in the release note section for unreleased versions for prs tagged `relnotes-perf` and `finished-final-comment-period`.

note: i did not test if this deployed locally as i couldn't get hugo to work, but i checked that the rust code generated the correct markdown.