### PR TITLE
perf(version_manager): use const for stable 1.0.0 check

### DIFF
--- a/src/version_manager.rs
+++ b/src/version_manager.rs
@@ -17,6 +17,8 @@ pub struct VersionManager {
     config: Config,
 }
 
+const STABLE: Version = Version::new(1, 0, 0);
+
 impl VersionManager {
     pub fn new(config: Config) -> Self {
         Self { config }
@@ -51,7 +53,7 @@ impl VersionManager {
                     let version = &s[0..ws_idx];
                     let time: NaiveDate = s[ws_idx + 1..].trim_start()[1..11].parse().unwrap();
                     if let Ok(version) = Version::parse(version) {
-                        if version > Version::from_str("1.0.0").unwrap() {
+                        if version > STABLE {
                             let changelog = rest.lines().skip(2).collect::<Vec<_>>().join("\n");
                             Some((version, (changelog, time)))
                         } else {


### PR DESCRIPTION
Instead of building it every time we can just refactor this into a constant.