### PR TITLE
fix(version_manager): make semver more lenient for 1.90

### DIFF
--- a/src/version_manager.rs
+++ b/src/version_manager.rs
@@ -17,6 +17,18 @@ pub struct VersionManager {
     config: Config,
 }
 
+// We do this because of https://github.com/rust-lang/rust/commit/495d7ee587dc1b8d99fd9f0bce2f72b0072e3aca
+// So we'll be a bit permissive with such cases where the minor version is missing
+fn parse_lenient_version(version: &str) -> Option<Version> {
+    let splits = version.split('.').count();
+
+    if splits < 3 {
+        return Version::parse(&format!("{version}.0")).ok()
+    }
+
+    Version::parse(version).ok()
+}
+
 impl VersionManager {
     pub fn new(config: Config) -> Self {
         Self { config }
@@ -50,7 +62,7 @@ impl VersionManager {
                     let rest = &s[ws_idx..];
                     let version = &s[0..ws_idx];
                     let time: NaiveDate = s[ws_idx + 1..].trim_start()[1..11].parse().unwrap();
-                    if let Ok(version) = Version::parse(version) {
+                    if let Some(version) = parse_lenient_version(version) {
                         if version > Version::from_str("1.0.0").unwrap() {
                             let changelog = rest.lines().skip(2).collect::<Vec<_>>().join("\n");
                             Some((version, (changelog, time)))


### PR DESCRIPTION
Closes #39, not sure if this is the best approach there is, but gets stuff fixed for now at least.
I made the function return `Option` because I see that we are not using the error in any way.

EDIT: with this, we might also be able to bring pre-1.0 versions on the site, but this'll come separately.