### PR TITLE
feat: update theme/hugo-book submodule

### DIFF
--- a/.github/workflows/periodic-build.yaml
+++ b/.github/workflows/periodic-build.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.137.1'
+          hugo-version: '0.146.7'
           extended: true
 
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ the pages periodically.
 
 ## Building
 
-Note: this requires [hugo](https://gohugo.io/)
+Note: this requires [hugo](https://gohugo.io/) 0.146.7 or higher.
 
 ```shell
 git clone --recurse-submodules git@github.com:releases-rs/releases-rs

--- a/hugo/rust-changelogs/assets/_custom.scss
+++ b/hugo/rust-changelogs/assets/_custom.scss
@@ -1,0 +1,67 @@
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&family=Roboto+Mono:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;1,100;1,200;1,300;1,400;1,500;1,600;1,700&display=swap');
+
+* {
+  font-family: 'Roboto', sans-serif !important;
+  letter-spacing: 0.33px;
+}
+
+code,
+pre,
+kbd,
+samp,
+.markdown pre,
+.markdown code,
+.highlight,
+.highlight pre,
+.highlight code {
+  font-family: 'Roboto Mono', monospace !important;
+  letter-spacing: 0.33px;
+}
+
+.markdown details summary::before {
+  content: none !important;
+}
+
+.markdown details summary {
+  list-style-position: inside;
+  list-style-type: disclosure-closed;
+}
+
+.markdown details[open] summary {
+  list-style-position: inside;
+  list-style-type: disclosure-open;
+}
+
+#book-search-input {
+  letter-spacing: normal;
+}
+
+.book-toc-content a {
+  padding-top: 0;
+  padding-bottom: 1em;
+}
+
+.book-brand {
+    img {
+        margin-inline-end: 8px;
+    }
+
+    a {
+        gap: 0;
+    }
+}
+
+.book-search {
+    margin: 16px 0;
+}
+
+.book-menu-content {
+    li {
+        margin: 14px 0;
+
+        a {
+            padding: 0;
+        }
+    }
+}

--- a/hugo/rust-changelogs/config.toml
+++ b/hugo/rust-changelogs/config.toml
@@ -3,6 +3,11 @@ languageCode = 'en-us'
 title = 'Rust Changelogs'
 googleAnalytics = 'G-WXS0HSEV58'
 
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+
 [params]
 BookLogo = 'https://www.rust-lang.org/static/images/rust-logo-blk.svg'
 BookTheme = 'auto'

--- a/src/changelog_generator.rs
+++ b/src/changelog_generator.rs
@@ -41,10 +41,10 @@ weight: {weight}
 {version}
 =========
 
-{{{{< hint info >}}}}
+{{{{% hint info %}}}}
 - Released on: _{release_date}_
 {version_branch_info_str}
-{{{{< /hint >}}}}
+{{{{% /hint %}}}}
 
 {trimmed}
 ",
@@ -79,12 +79,12 @@ weight: {weight}
 {unreleased_version} {release_name}
 =========
 
-{{{{< hint warning >}}}}
+{{{{% hint warning %}}}}
 **Unreleased{release_sfx}**
 
 - Will be stable on: _{stable_date}_
 - {branch_pfx} from master on: _{branch_date}_
-{{{{< /hint >}}}}
+{{{{% /hint %}}}}
 
 ",
             weight = self.version_manager.determine_weight(unreleased_version),
@@ -171,7 +171,7 @@ type: docs
             let mut line = "".to_string();
             let title = title.replace('"', "\\\"");
             line.push_str(&format!(
-                "{{{{<details \"{title} ({days_ago_text} old)\">}}}}\n"
+                "{{{{% details \"{title} ({days_ago_text} old)\" %}}}}\n"
             ));
             labels.into_iter().for_each(|label| {
                 line.push_str("* _");
@@ -184,7 +184,7 @@ type: docs
                 line.push('\n');
             });
             line.push_str(&format!("\n[Open PR #{number}]({html_url})\n\n"));
-            line.push_str("{{</details>}}\n");
+            line.push_str("{{% /details %}}\n");
             index.push_str(&line);
         }
 

--- a/src/hugo_manager.rs
+++ b/src/hugo_manager.rs
@@ -40,7 +40,8 @@ impl HugoManager {
     pub fn build_site(&self) -> Result<()> {
         let res = std::process::Command::new("hugo")
             .arg("--minify")
-            .arg("--debug")
+            .arg("--logLevel")
+            .arg("debug")
             .arg("--theme")
             .arg("hugo-book")
             .current_dir("hugo/rust-changelogs")


### PR DESCRIPTION
Whilst setting up the project, I encountered an issue with building the project because of the theme (and because I was running latest hugo):

```
ERROR deprecated: .Sites.First was deprecated in Hugo v0.127.0 and subsequently removed. Use .Sites.Default instead.
ERROR TOCSS: failed to transform "book.scss" (text/x-scss). Check your Hugo installation; you need the extended version to build SCSS/SASS with transpiler set to 'libsass'.: this feature is not available in your current Hugo version, see https://goo.gl/YMrWcn for more information
```

This PR updates the submodule to the latest available release (from `v10` to ~`v11`~ `master` (see comment below)).