### PR TITLE
feat: bring pre-stable versions to the site

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,11 @@
+pub mod changelog_generator;
+pub mod config;
+pub mod github_client;
+pub mod hugo_manager;
+pub mod version_manager;
+
+pub use changelog_generator::ChangelogGenerator;
+pub use config::Config;
+pub use github_client::GitHubClient;
+pub use hugo_manager::HugoManager;
+pub use version_manager::VersionManager;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ async fn main() -> Result<()> {
     let changelogs = version_manager.parse_changelogs(&body);
 
     for (version, (changelog, release_date)) in changelogs.iter() {
-        println!("{version:#?}");
         let content = changelog_generator.generate_released_version_content(version, changelog, release_date);
         hugo_manager.write_version_file(version, &content)?;
     }

--- a/tests/version_manager.rs
+++ b/tests/version_manager.rs
@@ -1,0 +1,30 @@
+
+use semver::Version;
+use rust_changelogs::{Config, VersionManager};
+
+#[test]
+fn version_weights() {
+    let config = Config::new();
+    let version_manager = VersionManager::new(config);
+
+    let versions = vec![
+        Version::parse("1.90.0").unwrap(),
+        Version::parse("1.85.1").unwrap(),
+        Version::parse("1.1.0").unwrap(),
+        Version::parse("1.0.0").unwrap(),
+        Version::parse("1.0.0-alpha.2").unwrap(),
+        Version::parse("1.0.0-alpha").unwrap(),
+        Version::parse("0.12.0").unwrap(),
+    ];
+
+    let mut weights: Vec<_> = versions.iter()
+        .map(|v| (v, version_manager.determine_weight(v)))
+        .collect();
+
+    // Sort like this to match the site
+    weights.sort_by(|a, b| a.1.cmp(&b.1));
+
+    for (index, (version, _)) in weights.into_iter().enumerate() {
+        assert_eq!(version, &versions[index]);
+    }
+}

--- a/tests/version_manager.rs
+++ b/tests/version_manager.rs
@@ -1,6 +1,7 @@
 
 use semver::Version;
 use rust_changelogs::{Config, VersionManager};
+use itertools::Itertools;
 
 #[test]
 fn version_weights() {
@@ -17,14 +18,13 @@ fn version_weights() {
         Version::parse("0.12.0").unwrap(),
     ];
 
-    let mut weights: Vec<_> = versions.iter()
+    let weights: Vec<_> = versions.iter()
         .map(|v| (v, version_manager.determine_weight(v)))
+        .sorted_by(|a, b| a.1.cmp(&b.1))
+        .map(|(v, _)| v)
         .collect();
 
-    // Sort like this to match the site
-    weights.sort_by(|a, b| a.1.cmp(&b.1));
-
-    for (index, (version, _)) in weights.into_iter().enumerate() {
+    for (index, version) in weights.into_iter().enumerate() {
         assert_eq!(version, &versions[index]);
     }
 }


### PR DESCRIPTION
By changing how `determine_weight` is being computed (because of tags with prefixes, such as `1.0.0-alpha.2`).
Also added tests in case we change this to make sure we dont break stuff (will open soon a PR to add tests to CI).