### PR TITLE
feat(github_client): provide token via env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+.env

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ cd releases-rs
 cargo run
 ```
 
+Note: if the GitHub API rate limit is reached, a [personal access token (classic)](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#types-of-personal-access-tokens)
+can be provided via the `GITHUB_TOKEN` env.
+
 When done you will have your generated pages in `hugo/rust-changelogs/public`.
 
 ### Serving Locally

--- a/src/github_client.rs
+++ b/src/github_client.rs
@@ -7,18 +7,23 @@ use octocrab::params::{issues, Direction, State};
 use octocrab::Octocrab;
 use semver::Version;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 #[derive(Debug)]
 pub struct GitHubClient {
-    octocrab: Arc<Octocrab>,
+    octocrab: Octocrab,
     config: Config,
 }
 
 impl GitHubClient {
     pub fn new(config: Config) -> Self {
+        let mut builder = Octocrab::builder();
+        let token = std::env::var("GITHUB_TOKEN").ok();
+        if let Some(token) = token {
+            builder = builder.personal_token(token);
+        }
+
         Self {
-            octocrab: Arc::new(Octocrab::builder().build().unwrap()),
+            octocrab: builder.build().unwrap(),
             config,
         }
     }


### PR DESCRIPTION
Whilst testing, i quickly hit the GitHub API rate limits, my solution to this was to modify the client to add my token explicitly, so this PR makes this easier to do so.

Usage example:
`GITHUB_TOKEN=my_token cargo r`

EDIT: I've also added `.env` to git ignore rules, although we don't explicitly import it its easier to keep it in place with the project.
