### PR TITLE
feat(changelog_generator): show time in local

### DIFF
--- a/hugo/rust-changelogs/layouts/partials/docs/inject/body.html
+++ b/hugo/rust-changelogs/layouts/partials/docs/inject/body.html
@@ -1,2 +1,1 @@
-
 <script src="{{ "js/local-time.js" | relURL }}"></script>

--- a/hugo/rust-changelogs/layouts/partials/docs/inject/body.html
+++ b/hugo/rust-changelogs/layouts/partials/docs/inject/body.html
@@ -1,0 +1,2 @@
+
+<script src="{{ "js/local-time.js" | relURL }}"></script>

--- a/hugo/rust-changelogs/static/js/local-time.js
+++ b/hugo/rust-changelogs/static/js/local-time.js
@@ -1,0 +1,20 @@
+
+// Convert UTC timestamps to local time
+document.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('.utc-timestamp').forEach(function(element) {
+        const utcTimestamp = element.getAttribute('data-utc');
+
+        try {
+            const utcDate = new Date(utcTimestamp);
+            
+            element.innerHTML = `${utcDate.toLocaleString()}`;
+            
+            element.setAttribute('title', `UTC: ${utcDate.toUTCString()}`);
+            
+            element.style.cursor = 'help';
+            element.style.borderBottom = '1px dotted #666';
+        } catch (error) {
+            console.warn('Failed to parse UTC timestamp:', utcTimestamp, error);
+        }
+    });
+});

--- a/src/changelog_generator.rs
+++ b/src/changelog_generator.rs
@@ -194,10 +194,10 @@ type: docs
 ## About releases.rs
 
 - [Github Repo](https://github.com/releases-rs/releases-rs/)
-- Generated at _{}
+- Generated at <span class=\"utc-timestamp\" data-utc=\"{}\">...</span>
 
 ",
-            Utc::now().to_rfc2822()
+            Utc::now().to_rfc3339()
         ));
 
         index


### PR DESCRIPTION
Instead of showing the time in UTC, show it in the user's locale by injecting a js script on load.

Before:
> Generated at _Thu, 25 Sep 2025 11:21:55 +0000

After:
> Generated at 9/25/2025, 3:29:27 PM

(with a tip that shows the time in UTC)